### PR TITLE
bugfix: array of data did not merge objects recursively, now does

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 npm-debug.log
 tmp
+# IDE files
+.idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,6 +83,18 @@ module.exports = function(grunt) {
           }
         ]
       },
+      multiple_data_deep: {
+        files: [
+          {
+            data: [
+              {main: {greeting: "Hello"}},
+              {main: {reversed_target: "dlrow"}}
+            ],
+            template: 'test/fixtures/templates/hello_world_deep.twig',
+            dest: 'tmp/hello_world_multiple_data_deep.html'
+          }
+        ]
+      },
       src_as_data_file: {
         files: [
           {

--- a/README.md
+++ b/README.md
@@ -443,6 +443,10 @@ options:
 
 ## Release History
 
+__1.7.1__
+
+  * bugfix: array of data did not merge objects recursively, now does.
+
 __1.7.0__
 
   * added `cache` option to enable/disable Twig caching (needed for livereload).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-twig-render",
   "description": "Render twig templates",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "homepage": "https://github.com/sullinger/grunt-twig-render",
   "author": {
     "name": "Stefan Ullinger",

--- a/tasks/twigRender.js
+++ b/tasks/twigRender.js
@@ -129,7 +129,7 @@ module.exports = function(grunt) {
       var mergedData = {};
       data.forEach(function(item) {
         item = this._getData(item);
-        mergedData = merge(mergedData, item);
+        mergedData = merge.recursive(mergedData, item);
       }.bind(this));
       rawData =  mergedData;
     }

--- a/test/fixtures/templates/hello_world_deep.twig
+++ b/test/fixtures/templates/hello_world_deep.twig
@@ -1,0 +1,5 @@
+{% include "partials/head.twig" %}
+<body>
+  <h1>{{ main.greeting }}, {{ main.reversed_target|reverse|capitalize }}!</h1>
+</body>
+</html>

--- a/test/twig_render_test.js
+++ b/test/twig_render_test.js
@@ -75,6 +75,11 @@ exports.twigRender = {
     testFilesEqual(test, 'tmp/hello_planet_multiple_data.html', 'test/expected/hello_planet_multiple_data.html', 'should render when given array of data items.');
     test.done();
   },
+  multiple_data_deep: function(test) {
+    test.expect(1);
+    testFilesEqual(test, 'tmp/hello_world_multiple_data_deep.html', 'test/expected/hello_world.html', 'should merge deep items too.');
+    test.done();
+  },
   src_as_data_file: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
Hi,

When using an array for data, intended behavior is to merge data, from left to right.

This worked at first level, but failed if data trees were deeper:
```javascript
data: [
  {main: {foo:1}},
  {main: {bar:2}},
]
```
resulted in data= `{main: {bar:2}}`, whereas it should be `{main: {foo: 1, bar:2}}`.

This PR fixes it (including test, version bump, readme update).