### PR TITLE
Twig errors now cause grunt fails and display

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -153,31 +153,25 @@ module.exports = function(grunt) {
           }
         ]
       },
-
       twig_filter_extensions: {
         options: {
           extensions: [
-
             function(Twig) {
               Twig.exports.extendFilter( "fooJoin", function(value, params) {
                 if (value === undefined || value === null) {
                   return;
                 }
-
                 var join_str = "",
                     output = [],
                     keyset = null;
-
                 if (params && params[0]) {
                     join_str = params[0];
                 }
-              
                 if (value instanceof Array) {
                   output = value;
                 }
                 else {
                   keyset = value._keys || Object.keys(value);
-                  
                   Twig.forEach(keyset, function(key) {
                     if (key === "_keys") {
                       return; // Ignore the _keys property
@@ -188,14 +182,12 @@ module.exports = function(grunt) {
                     }
                   });
                 }
-              
                 return output.join(join_str);
               });
             }
             
           ]
         },
-
         files: [
           {
             data: {},
@@ -207,17 +199,14 @@ module.exports = function(grunt) {
       twig_function_extensions: {
         options: {
           extensions: [
-
             function(Twig) {
               Twig.exports.extendFunction( "fooCycle", function(arr, i) {
                 var pos = i % arr.length;
                 return arr[pos];
               });
             }
-
           ]
         },
-
         files: [
           {
             data: {},
@@ -229,7 +218,6 @@ module.exports = function(grunt) {
       twig_tag_extensions: {
         options: {
           extensions: [
-
             function(Twig) {
               Twig.exports.extendTag({
               
@@ -239,19 +227,14 @@ module.exports = function(grunt) {
                   "endFooSpaceless"
                 ],
                 open: true,
-
                 // Parse the html and return it without any spaces between tags
                 parse: function (token, context, chain) {
-
                   var // Parse the output without any filter
                   unfiltered = Twig.parse.apply(this, [token.output, context]),
-
                   // A regular expression to find closing and opening tags with spaces between them
                   rBetweenTagSpaces = />\s+</g,
-                  
                   // Replace all space between closing and opening html tags
                   output = unfiltered.replace(rBetweenTagSpaces,'><').trim();
-
                   return {
                     chain: chain,
                     output: output
@@ -260,20 +243,16 @@ module.exports = function(grunt) {
 
               });
             },
-
             function(Twig) {
               Twig.exports.extendTag({
-              
                 type: "endFooSpaceless",
                 regex: /^endFooSpaceless$/,
                 next: [ ],
                 open: false
-
               });
             }
           ]
         },
-
         files: [
           {
             data: {},
@@ -282,7 +261,6 @@ module.exports = function(grunt) {
           }
         ]
       }
-      
     },
 
     // Unit tests.

--- a/tasks/twigRender.js
+++ b/tasks/twigRender.js
@@ -179,21 +179,25 @@ module.exports = function(grunt) {
   };
 
   grunt.registerMultiTask('twigRender', 'Render twig templates', function() {
-    var renderer = new GruntTwigRender(this.options);
-    this.files.forEach(function(fileData) {
-      // We want to allow globbing of data OR templates (can't do both),
-      // but globbing expands the src parameter only.
-      // So we use src as the moving parameter, the other one (data or template)
-      // MUST be specified.
-      var src = fileData.src;
-      if (src && isArray(src)) {src = src[0];}
-      if(src && !fileData.template) {fileData.template = src;}
-      if(src && !fileData.data) {fileData.data = src;}
+    try {
+      var renderer = new GruntTwigRender(this.options);
+      this.files.forEach(function(fileData) {
+        // We want to allow globbing of data OR templates (can't do both),
+        // but globbing expands the src parameter only.
+        // So we use src as the moving parameter, the other one (data or template)
+        // MUST be specified.
+        var src = fileData.src;
+        if (src && isArray(src)) {src = src[0];}
+        if(src && !fileData.template) {fileData.template = src;}
+        if(src && !fileData.data) {fileData.data = src;}
 
-      renderer.render(fileData.data, fileData.dataPath, fileData.template, fileData.dest, fileData.flatten);
-      grunt.log.writeln('File ' + chalk.cyan(fileData.dest) + ' created.');
-    });
-
+        renderer.render(fileData.data, fileData.dataPath, fileData.template, fileData.dest, fileData.flatten);
+        grunt.log.writeln('File ' + chalk.cyan(fileData.dest) + ' created.');
+      });
+    } catch(err) {
+      // Fail the build if Twig.Error was thrown
+      grunt.fail.fatal(err);
+    }
   });
 
 };


### PR DESCRIPTION
Twig errors caused the file generation to silently fail but grunt continued and no message was displayed.
This made build issues hard to fix.

This patch causes grunt to halt and display the Twig error message in these cases.